### PR TITLE
Enable automatic dependency upgrades for test server

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,17 @@
 version: 2
 
 updates:
+  - package-ecosystem: "npm"
+    directory: "/src/node"
+    schedule:
+      interval: "daily"
+    labels:
+      - "C-dependency"
+    assignees:
+      - "jdno"
+    reviewers:
+      - "jdno"
+
   - package-ecosystem: "cargo"
     directory: "/src/rust"
     schedule:
@@ -13,8 +24,8 @@ updates:
     reviewers:
       - "jdno"
 
-  - package-ecosystem: "npm"
-    directory: "/src/node"
+  - package-ecosystem: "cargo"
+    directory: "/tests"
     schedule:
       interval: "daily"
     labels:


### PR DESCRIPTION
Dependabot has been configured to keep the dependencies of the test
server for integrations tests up to date.