### PR TITLE
Symlink Protobufs into Rust crate

### DIFF
--- a/languages/rust/build.rs
+++ b/languages/rust/build.rs
@@ -1,8 +1,7 @@
 use std::path::PathBuf;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let root_path = find_project_root().unwrap();
-    let proto_path = root_path.join("protobufs");
+    let proto_path = PathBuf::from("protobufs");
 
     let build_server = std::env::var("CARGO_FEATURE_SERVER").is_ok();
 
@@ -14,18 +13,4 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         )?;
 
     Ok(())
-}
-
-fn find_project_root() -> Option<PathBuf> {
-    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-
-    while let Some(parent) = path.parent() {
-        path = parent.to_path_buf();
-
-        if path.ends_with("lunaria-api") {
-            return Some(path);
-        }
-    }
-
-    None
 }

--- a/languages/rust/protobufs
+++ b/languages/rust/protobufs
@@ -1,0 +1,1 @@
+../../protobufs


### PR DESCRIPTION
Rust requires the Protocol Buffers to be distributed with the crate,
because otherwise the code generation will fail. This has not shown up
as an issue yet because we used relative paths for the dependency so
far, but now that the crate has been published to crates.io it got
reported.

We still want to have the Protocol Buffers at the root of the
repository, because they are not a feature specific to the Rust
implementation. So they have been symlinked into the Rust crate.
Symlinks can cause some issues with Git, so this is considered a
temporary workaround until a proper solution can be found.

See <https://github.com/playlunaria/lunaria/issues/20> for the bug
report.