### PR TITLE
Remove overwrite for lint rule

### DIFF
--- a/.github/workflows/protobuf.yml
+++ b/.github/workflows/protobuf.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install buf from binary
         if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         run: |
-          VERSION="0.25.0"
+          VERSION="0.43.2"
           BIN="/usr/local/bin"
           BINARY_NAME="buf"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Rename gRPC service `Lunaria` to `LunariaService`
+
 ## [0.1.1] - 2020-10-29
 
 ### Fixed
 
-- Include Protocol Buffers in Rust crate to fix build errors (#22)
+- Include Protocol Buffers in Rust crate to fix build errors
 
 ## [0.1.0] - 2020-10-17
 

--- a/languages/rust/src/lib.rs
+++ b/languages/rust/src/lib.rs
@@ -30,7 +30,7 @@
 //! # Examples
 //!
 //! ```rust
-//! use lunaria_api::lunaria::v1::lunaria_client::LunariaClient;
+//! use lunaria_api::lunaria::v1::lunaria_service_client::LunariaServiceClient;
 //! use lunaria_api::lunaria::v1::{GetVersionRequest, GetVersionResponse, Version};
 //! use tonic::Request;
 //!
@@ -40,7 +40,7 @@
 //!     let address = "http://127.0.0.1:1904";
 //!
 //!     // Initialize the client
-//!     let mut lunaria = LunariaClient::connect(address).await?;
+//!     let mut lunaria = LunariaServiceClient::connect(address).await?;
 //!
 //!     // Create a request to get the game's version and send it to the server
 //!     let request = Request::new(GetVersionRequest {});

--- a/protobufs/buf.yaml
+++ b/protobufs/buf.yaml
@@ -1,6 +1,2 @@
 ---
 version: v1beta1
-
-lint:
-  except:
-    - SERVICE_SUFFIX

--- a/protobufs/lunaria/v1/lunaria.proto
+++ b/protobufs/lunaria/v1/lunaria.proto
@@ -13,6 +13,6 @@ message GetVersionResponse {
   Version version = 1;
 }
 
-service Lunaria {
+service LunariaService {
   rpc GetVersion(GetVersionRequest) returns (GetVersionResponse);
 }

--- a/test-server/src/main.rs
+++ b/test-server/src/main.rs
@@ -1,4 +1,4 @@
-use lunaria_api::lunaria::v1::lunaria_server::LunariaServer;
+use lunaria_api::lunaria::v1::lunaria_service_server::LunariaServiceServer;
 use lunaria_api::lunaria::v1::{GetVersionRequest, GetVersionResponse, Version};
 use tonic::transport::Server;
 use tonic::{Request, Response, Status};
@@ -7,7 +7,7 @@ use tonic::{Request, Response, Status};
 struct Lunaria {}
 
 #[tonic::async_trait]
-impl lunaria_api::lunaria::v1::lunaria_server::Lunaria for Lunaria {
+impl lunaria_api::lunaria::v1::lunaria_service_server::LunariaService for Lunaria {
     async fn get_version(
         &self,
         _request: Request<GetVersionRequest>,
@@ -33,7 +33,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let lunaria = Lunaria::default();
 
     Server::builder()
-        .add_service(LunariaServer::new(lunaria))
+        .add_service(LunariaServiceServer::new(lunaria))
         .serve(address)
         .await?;
 


### PR DESCRIPTION
The Lunaria service has been renamed to LunariaService, following the
best practices for gRPC. Ignoring the rule was premature, and at this
point it is better that we follow the guidelines until we have a better
understanding of the gRPC ecosystem.