### PR TITLE
Run checks on each push

### DIFF
--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -9,19 +9,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Determine if files changed
-        uses: fkirc/skip-duplicate-actions@v3.4.0
-        id: skip_check
-        with:
-          paths: '["**.md"]'
-
       - name: Checkout code
         uses: actions/checkout@v2
-        if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
 
       - name: markdownlint-cli
         uses: nosborn/github-action-markdown-cli@v1.1.1
-        if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         with:
           files: "**.md"
 
@@ -30,19 +22,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Determine if files changed
-        uses: fkirc/skip-duplicate-actions@v3.4.0
-        id: skip_check
-        with:
-          paths: '["**.md"]'
-
       - name: Checkout code
         uses: actions/checkout@v2
-        if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
 
       - name: prettier
         uses: creyD/prettier_action@v3.3
-        if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         with:
           dry: true
           prettier_options: "--check **.md"

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -9,30 +9,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Determine if files changed
-        uses: fkirc/skip-duplicate-actions@v3.4.0
-        id: skip_check
-        with:
-          paths: '["**.js", "**.ts", "**.json", "**.lock"]'
-
       - name: Checkout code
         uses: actions/checkout@v2
-        if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
 
       - name: Set up Node
         uses: actions/setup-node@v1
-        if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         with:
           node-version: 12
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
-        if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         with:
           working-directory: languages/node
 
       - name: Lint project
-        if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         working-directory: languages/node
         run: yarn lint
 
@@ -41,23 +31,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Determine if files changed
-        uses: fkirc/skip-duplicate-actions@v3.4.0
-        id: skip_check
-        with:
-          paths: '["**.js", "**.ts", "**.json", "**.lock"]'
-
       - name: Install system dependencies
-        if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
       - name: Checkout code
         uses: actions/checkout@v2
-        if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
 
       - name: Cache build artifacts
         uses: actions/cache@v2.1.6
-        if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         with:
           path: |
             test-server/.cargo/registry
@@ -68,35 +49,43 @@ jobs:
 
       - name: Set up Rust toolchain
         uses: actions-rs/toolchain@v1
-        if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         with:
           toolchain: stable
           override: true
 
       - name: Build test server
         uses: actions-rs/cargo@v1
-        if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         with:
           command: build
           args: --manifest-path test-server/Cargo.toml
 
       - name: Set up Node
         uses: actions/setup-node@v1
-        if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         with:
           node-version: 12
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
-        if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         with:
           working-directory: languages/node
 
       - name: Build Node client
-        if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         working-directory: languages/node
         run: yarn build
 
       - name: Run tests
-        if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         run: bin/test-node
+
+  style:
+    name: Style
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: prettier
+        uses: creyD/prettier_action@v3.3
+        with:
+          dry: true
+          prettier_options: "--check **.{js,json,ts}"

--- a/.github/workflows/protobuf.yml
+++ b/.github/workflows/protobuf.yml
@@ -9,18 +9,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Determine if files changed
-        uses: fkirc/skip-duplicate-actions@v3.4.0
-        id: skip_check
-        with:
-          paths: '["**.proto"]'
-
       - name: Checkout code
         uses: actions/checkout@v2
-        if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
 
       - name: Install buf from binary
-        if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         run: |
           VERSION="0.43.2"
           BIN="/usr/local/bin"
@@ -33,7 +25,6 @@ jobs:
           sudo chmod +x "${BIN}/${BINARY_NAME}"
 
       - name: Lint Protocol Buffers
-        if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         run: |
           cd protobufs
           buf check lint

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,19 +9,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Determine if files changed
-        uses: fkirc/skip-duplicate-actions@v3.4.0
-        id: skip_check
-        with:
-          paths: '["**.rs", "**Cargo.{toml,lock}"]'
-
       - name: Checkout code
         uses: actions/checkout@v2
-        if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
 
       - name: Cache build artifacts
         uses: actions/cache@v2.1.6
-        if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         with:
           path: |
             languages/rust/.cargo/registry
@@ -35,14 +27,12 @@ jobs:
 
       - name: Set up Rust toolchain
         uses: actions-rs/toolchain@v1
-        if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         with:
           toolchain: stable
           override: true
 
       - name: Run Clippy
         uses: actions-rs/cargo@v1
-        if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         with:
           command: clippy
           args: --manifest-path languages/rust/Cargo.toml --all-targets --all-features -- -D warnings
@@ -52,19 +42,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Determine if files changed
-        uses: fkirc/skip-duplicate-actions@v3.4.0
-        id: skip_check
-        with:
-          paths: '["**.rs", "**Cargo.{toml,lock}"]'
-
       - name: Checkout code
         uses: actions/checkout@v2
-        if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
 
       - name: Set up Rust toolchain
         uses: actions-rs/toolchain@v1
-        if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         with:
           profile: minimal
           toolchain: stable
@@ -73,7 +55,6 @@ jobs:
 
       - name: Run Rustfmt
         uses: actions-rs/cargo@v1
-        if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         with:
           command: fmt
           args: --manifest-path languages/rust/Cargo.toml --all -- --check
@@ -86,19 +67,11 @@ jobs:
       LUNARIA_ADDRESS: 127.0.0.1:1904
 
     steps:
-      - name: Determine if files changed
-        uses: fkirc/skip-duplicate-actions@v3.4.0
-        id: skip_check
-        with:
-          paths: '["**.rs", "**Cargo.{toml,lock}"]'
-
       - name: Checkout code
         uses: actions/checkout@v2
-        if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
 
       - name: Cache build artifacts
         uses: actions/cache@v2.1.6
-        if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         with:
           path: |
             languages/rust/.cargo/registry
@@ -112,25 +85,21 @@ jobs:
 
       - name: Set up Rust toolchain
         uses: actions-rs/toolchain@v1
-        if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         with:
           toolchain: stable
           override: true
 
       - name: Build test server
         uses: actions-rs/cargo@v1
-        if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         with:
           command: build
           args: --manifest-path test-server/Cargo.toml
 
       - name: Build crate
         uses: actions-rs/cargo@v1
-        if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         with:
           command: build
           args: --manifest-path languages/rust/Cargo.toml
 
       - name: Run tests
         run: bin/test-rust
-        if: ${{ steps.skip_check.outputs.should_skip != 'true' }}

--- a/.github/workflows/yaml.yml
+++ b/.github/workflows/yaml.yml
@@ -9,38 +9,22 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Determine if files changed
-        uses: fkirc/skip-duplicate-actions@v3.4.0
-        id: skip_check
-        with:
-          paths: '["**.yaml", "**.yml"]'
-
       - name: Checkout code
         uses: actions/checkout@v2
-        if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
 
       - name: Run yamllint
         uses: actionshub/yamllint@1.0.0
-        if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
 
   style:
     name: Style
     runs-on: ubuntu-latest
 
     steps:
-      - name: Determine if files changed
-        uses: fkirc/skip-duplicate-actions@v3.4.0
-        id: skip_check
-        with:
-          paths: '["**.yaml", "**.yml"]'
-
       - name: Checkout code
         uses: actions/checkout@v2
-        if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
 
       - name: prettier
         uses: creyD/prettier_action@v3.3
-        if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         with:
           dry: true
           prettier_options: "--check **.{yml,yaml}"

--- a/languages/node/.eslintrc.js
+++ b/languages/node/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  rules: {
+    "prettier/prettier": "off",
+  },
+};

--- a/languages/node/README.md
+++ b/languages/node/README.md
@@ -29,12 +29,12 @@ check out the specification of Lunaria's API:
 import {
   GetVersionRequest,
   GetVersionResponse,
-  LunariaClient,
+  LunariaServiceClient,
 } from "lunaria-api";
 import * as grpc from "@grpc/grpc-js";
 
 // Initialize a new API client
-const lunaria = new LunariaClient(
+const lunaria = new LunariaServiceClient(
   "127.0.0.1:1904",
   grpc.credentials.createInsecure()
 );

--- a/languages/node/test/version.test.ts
+++ b/languages/node/test/version.test.ts
@@ -1,7 +1,11 @@
-import { GetVersionRequest, GetVersionResponse, LunariaClient } from "../src";
+import {
+  GetVersionRequest,
+  GetVersionResponse,
+  LunariaServiceClient,
+} from "../src";
 import * as grpc from "@grpc/grpc-js";
 
-const lunaria = new LunariaClient(
+const lunaria = new LunariaServiceClient(
   "127.0.0.1:1904",
   grpc.credentials.createInsecure()
 );

--- a/languages/rust/README.md
+++ b/languages/rust/README.md
@@ -35,7 +35,7 @@ data they require and return:
 Here is an example that fetches the version of the game:
 
 ```rust
-use lunaria_api::lunaria::v1::lunaria_client::LunariaClient;
+use lunaria_api::lunaria::v1::lunaria_service_client::LunariaSerrviceClient;
 use lunaria_api::lunaria::v1::{GetVersionRequest, GetVersionResponse, Version};
 use tonic::Request;
 
@@ -45,7 +45,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let address = "http://127.0.0.1:1904";
 
     // Initialize the client
-    let mut lunaria = LunariaClient::connect(address).await?;
+    let mut lunaria = LunariaServiceClient::connect(address).await?;
 
     // Create a request to get the game's version and send it to the server
     let request = Request::new(GetVersionRequest {});


### PR DESCRIPTION
We missed a regression in the last commit, since the checks for Node
didn't run based on our configuration. We only changed the Protocol
Buffers, which had an impact on the Node module. But because no
Javascript or TypeScript file changed, the Node action wasn't run and
the regression was missed.

While we could run the Node action when the Protocol Buffers change as
well, it is safer to simly default to running all actions al the time.
We don't expect this repository to change very frequently, and the
current actions are fast enough as they are.