### PR TITLE
Enable automatic updates of GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,14 @@
 version: 2
 
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "C-dependency"
+      - "PR-merge"
+
   - package-ecosystem: "npm"
     directory: "/languages/node"
     schedule:


### PR DESCRIPTION
Dependabot can automatically update GitHub Actions, which helps ensure
that the remote test environment is on similar versions as the local
development environment.