### PR TITLE
Add labels for different ecosystem

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -11,6 +11,15 @@
 - name: C-feature-request
   color: 1abc9c
   description: "Category: Feature requests"
+- name: E-node
+  color: 3498db
+  description: "Ecosystem: Node"
+- name: E-protobuf
+  color: 3498db
+  description: "Ecosystem: Protobufs"
+- name: E-rust
+  color: 3498db
+  description: "Ecosystem: Rust"
 - name: PR-block
   color: 3498db
   description: "Pull Request: Do not merge"


### PR DESCRIPTION
New GitHub issue labels have been added for the different ecosystems
that are part of this repository.