### PR TITLE
Make command to start a game a synchronous API call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change `startGame` method to return a message instead of a stream
+
 ## [0.2.0] – 2021-07-27
 
 ### Added

--- a/languages/node/test/game.test.ts
+++ b/languages/node/test/game.test.ts
@@ -8,11 +8,8 @@ const lunaria = new GameServiceClient(
 
 test("getVersion returns Lunaria's version", async () => {
   const request = new StartGameRequest();
-  const call = lunaria.startGame(request);
 
-  call.on("data", (response: StartGameResponse) => {
-    expect(response.getStatus()).toEqual(
-      StartGameResponse.GameStatus.GAME_STATUS_RUNNING
-    );
+  lunaria.startGame(request, (err, _response: StartGameResponse) => {
+    expect(err).toBeNull();
   });
 });

--- a/languages/rust/tests/game.rs
+++ b/languages/rust/tests/game.rs
@@ -3,7 +3,6 @@ use std::error::Error;
 use tonic::Request;
 
 use lunaria_api::lunaria::v1::game_service_client::GameServiceClient;
-use lunaria_api::lunaria::v1::start_game_response::GameStatus;
 use lunaria_api::lunaria::v1::StartGameRequest;
 
 #[tokio::test]
@@ -11,12 +10,11 @@ async fn test_start_game() -> Result<(), Box<dyn Error>> {
     let address = "http://127.0.0.1:1904";
 
     let mut game_service = GameServiceClient::connect(address).await?;
+
     let request = Request::new(StartGameRequest {});
+    let response = game_service.start_game(request).await;
 
-    let mut stream = game_service.start_game(request).await?.into_inner();
-    let status = stream.message().await?.unwrap();
-
-    assert_eq!(GameStatus::Running as i32, status.status);
+    assert!(response.is_ok());
 
     Ok(())
 }

--- a/protobufs/lunaria/v1/game.proto
+++ b/protobufs/lunaria/v1/game.proto
@@ -3,16 +3,8 @@ syntax = "proto3";
 package lunaria.v1;
 
 message StartGameRequest {}
-message StartGameResponse {
-  enum GameStatus {
-    GAME_STATUS_UNSPECIFIED = 0;
-    GAME_STATUS_LOADING = 1;
-    GAME_STATUS_RUNNING = 2;
-    GAME_STATUS_STOPPED = 3;
-  }
-  GameStatus status = 1;
-}
+message StartGameResponse {}
 
 service GameService {
-  rpc StartGame(StartGameRequest) returns (stream StartGameResponse);
+  rpc StartGame(StartGameRequest) returns (StartGameResponse);
 }

--- a/test-server/src/game.rs
+++ b/test-server/src/game.rs
@@ -1,11 +1,5 @@
-use std::pin::Pin;
-
-use tokio::sync::mpsc::channel;
-use tokio_stream::wrappers::ReceiverStream;
-use tonic::codegen::futures_core::Stream;
 use tonic::{Request, Response, Status};
 
-use lunaria_api::lunaria::v1::start_game_response::GameStatus;
 use lunaria_api::lunaria::v1::{StartGameRequest, StartGameResponse};
 
 #[derive(Clone, Debug, Default)]
@@ -13,23 +7,10 @@ pub struct Game {}
 
 #[tonic::async_trait]
 impl lunaria_api::lunaria::v1::game_service_server::GameService for Game {
-    type StartGameStream =
-        Pin<Box<dyn Stream<Item = Result<StartGameResponse, Status>> + Send + Sync + 'static>>;
-
     async fn start_game(
         &self,
         _request: Request<StartGameRequest>,
-    ) -> Result<Response<Self::StartGameStream>, Status> {
-        let (tx, rx) = channel(4);
-
-        tx.send(Ok(StartGameResponse {
-            status: GameStatus::Running.into(),
-        }))
-        .await
-        .unwrap();
-
-        Ok(Response::new(
-            Box::pin(ReceiverStream::new(rx)) as Self::StartGameStream
-        ))
+    ) -> Result<Response<StartGameResponse>, Status> {
+        Ok(Response::new(StartGameResponse {}))
     }
 }


### PR DESCRIPTION
The command to start a game has been changed to return a synchronous
response in place of a server-side stream. This simplifies the necessary
work to start a game, and reduces the barrier to entry for inexperienced
developers.